### PR TITLE
cease hiding import failures

### DIFF
--- a/snsmp2/__init__.py
+++ b/snsmp2/__init__.py
@@ -32,16 +32,10 @@
 
 __all__ = ['__version__']
 
-#try:
 import psi4
 import psi4.driver
 from .snsmp2 import run_sns_mp2
-print('AAAA', psi4.driver.procedures['energy'].keys())
-print('BBBB', run_sns_mp2)
 psi4.driver.procedures['energy']['sns-mp2'] = run_sns_mp2
-print('CCCC', psi4.driver.procedures['energy'].keys())
-#except ImportError:
-#    pass
 
 
 def _get_version():
@@ -49,6 +43,7 @@ def _get_version():
     resource = pkg_resources.Requirement.parse('snsmp2')
     provider = pkg_resources.get_provider(resource)
     return provider.version
+
 
 try:
     __version__ = _get_version()

--- a/snsmp2/__init__.py
+++ b/snsmp2/__init__.py
@@ -32,13 +32,16 @@
 
 __all__ = ['__version__']
 
-try:
-    import psi4
-    import psi4.driver
-    from .snsmp2 import run_sns_mp2
-    psi4.driver.procedures['energy']['sns-mp2'] = run_sns_mp2
-except ImportError:
-    pass
+#try:
+import psi4
+import psi4.driver
+from .snsmp2 import run_sns_mp2
+print('AAAA', psi4.driver.procedures['energy'].keys())
+print('BBBB', run_sns_mp2)
+psi4.driver.procedures['energy']['sns-mp2'] = run_sns_mp2
+print('CCCC', psi4.driver.procedures['energy'].keys())
+#except ImportError:
+#    pass
 
 
 def _get_version():


### PR DESCRIPTION
Is there a workflow where you want `import psi4, scipy` to fail silently? I've been trying to figure out why the build-snsmp2-on-demand version of psi is failing on travis for a week — just needed scipy to run. :-)