### PR TITLE
Psi4 physical constants update

### DIFF
--- a/snsmp2/desbasis.py
+++ b/snsmp2/desbasis.py
@@ -54,6 +54,6 @@ def _build_basis_funtion(name, spans):
         for span, target in spans.items():
             start, end = span.split('-')
             for z in range(int(start), int(end)+1):
-                symbol = periodictable.z2el[z]
+                symbol = periodictable.to_E(z)
                 mol.set_basis_by_symbol(symbol, str(target), role=role)
     return anon

--- a/snsmp2/format_output.py
+++ b/snsmp2/format_output.py
@@ -33,7 +33,7 @@
 import os
 import numpy as np
 from psi4 import core
-from psi4.driver.molutil import constants
+from psi4.driver import constants
 from .wavefunctioncache import dimerize, calcid
 
 

--- a/snsmp2/optstash.py
+++ b/snsmp2/optstash.py
@@ -78,7 +78,7 @@ class psiopts(ContextDecorator):
 
             # Integer options need to be passed as an integer type,
             # or else it fails to set and doesn't throw an error.
-            if re.match('^\d+$', v) is not None:
+            if re.match(r'^\d+$', v) is not None:
                 v = int(v)
 
             if len(k) == 1:

--- a/snsmp2/resources.py
+++ b/snsmp2/resources.py
@@ -65,6 +65,6 @@ def vminfo():
     with open('/proc/%s/status' % os.getpid()) as f:
         for line in f:
             if any(line.startswith(f) for f in fields):
-                m = re.match('(\w+):\s+(\d+)\skB', line)
+                m = re.match(r'(\w+):\s+(\d+)\skB', line)
                 return_value[m.group(1)] = int(m.group(2)) / 1024
     return return_value

--- a/snsmp2/wavefunctioncache.py
+++ b/snsmp2/wavefunctioncache.py
@@ -40,7 +40,7 @@ from collections import namedtuple
 from psi4 import core
 from psi4.driver.procrouting.proc import run_dfmp2, run_dfmp2_gradient
 from psi4.driver.procrouting.proc import scf_helper
-from psi4.driver.molutil import constants
+from psi4.driver import psif
 from psi4 import extras
 import psi4.driver.p4util as p4util
 from .optstash import psiopts
@@ -87,7 +87,7 @@ class WavefunctionCache(object):
             'low': low,
             'high': high,
         }
-        core.IOManager.shared_object().set_specific_retention(constants.PSIF_DFSCF_BJ, True)
+        core.IOManager.shared_object().set_specific_retention(psif.PSIF_DFSCF_BJ, True)
         os.chdir(core.IOManager.shared_object().get_default_path())
 
     def __enter__(self):
@@ -97,7 +97,7 @@ class WavefunctionCache(object):
 
         for calc in (calcid(*x) for x in itertools.product(('m1', 'm2', 'd'), ('m', 'd'), ('low', 'high'))):
             core.IO.set_default_namespace(self.fmt_ns(calc))
-            core.IOManager.shared_object().set_specific_retention(constants.PSIF_DFSCF_BJ, False)
+            core.IOManager.shared_object().set_specific_retention(psif.PSIF_DFSCF_BJ, False)
         try:
             extras.clean_numpy_files()
         except OSError:
@@ -236,7 +236,7 @@ class WavefunctionCache(object):
         # type: (calcid,) -> str
         # Path to the molecular orbital file for a calc.
         fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(self.fmt_ns(calc))))[1]
-        return "%s.%s.npz" % (fname, constants.PSIF_SCF_MOS)
+        return "%s.%s.npz" % (fname, psif.PSIF_SCF_MOS)
 
     def _init_addghost_C(self, oldcalc, calc):
         # print('Adding ghost %s->%s' % (oldcalc, calc))
@@ -337,7 +337,7 @@ class WavefunctionCache(object):
             for c in filter(lambda c: c in self.wfn_cache, candidates):
                 oldns = self.fmt_ns(c)
                 newns = self.fmt_ns(calc)
-                core.IO.change_file_namespace(constants.PSIF_DFSCF_BJ, oldns, newns)
+                core.IO.change_file_namespace(psif.PSIF_DFSCF_BJ, oldns, newns)
                 core.set_global_option("DF_INTS_IO", "LOAD")
         else:
             core.set_global_option("DF_INTS_IO", "NONE")


### PR DESCRIPTION
Psi4 has updated our physical constants to CODATA2014 and reorganized how we access them. (Now through https://github.com/MolSSI/QCElemental, which involves less manipulation between NIST and our header files.)

The result is that a few paths in snsmp2 need changing. If you'd be willing to merge this and mint a `v1.0.2`, I'd appreciate it. I'm glad to answer any questions you may have.