### PR TITLE
Fix orbital caching for Psi4 v1.3

### DIFF
--- a/snsmp2/__init__.py
+++ b/snsmp2/__init__.py
@@ -34,11 +34,6 @@ __all__ = ['__version__']
 
 import psi4
 import psi4.driver
-
-from pkg_resources import parse_version
-if parse_version(psi4.__version__) < parse_version('1.3rc2'):
-    raise ImportError('Psi4 {:s} is not compatible (v1.3+ necessary)'.format(psi4.__version__))
-
 from .snsmp2 import run_sns_mp2
 psi4.driver.procedures['energy']['sns-mp2'] = run_sns_mp2
 

--- a/snsmp2/__init__.py
+++ b/snsmp2/__init__.py
@@ -34,6 +34,11 @@ __all__ = ['__version__']
 
 import psi4
 import psi4.driver
+
+from pkg_resources import parse_version
+if parse_version(psi4.__version__) < parse_version('1.3rc2'):
+    raise ImportError('Psi4 {:s} is not compatible (v1.3+ necessary)'.format(psi4.__version__))
+
 from .snsmp2 import run_sns_mp2
 psi4.driver.procedures['energy']['sns-mp2'] = run_sns_mp2
 

--- a/snsmp2/eshlovlp.py
+++ b/snsmp2/eshlovlp.py
@@ -101,7 +101,7 @@ class HeitlerLondonFunctor(object):
         # At this point, it should be the case that
         # C.T * S * C == I
         np.testing.assert_array_almost_equal(
-            core.Matrix.triplet(C, self.p.dimer_S, C, True, False, False),
+            core.triplet(C, self.p.dimer_S, C, True, False, False),
             np.eye(nocc))
 
         self.jk.C_clear()
@@ -161,7 +161,7 @@ class EletrostaticsOverlapFunctor(object):
         J_1to2 = J.np[nbf1:, nbf1:]
         elel_1to2 = 2 * np.sum(J_1to2 * mol2_wfn.Da())
         nuel_1to2 = 2 * (self.p.dimer_V.vector_dot(D1) - self.p.monomer1_V.vector_dot(mol1_wfn.Da()))
-        ovlp1 = core.Matrix.doublet(self.p.dimer_S, D1, False, False)
+        ovlp1 = core.doublet(self.p.dimer_S, D1, False, False)
 
         #######################################################################
 
@@ -189,7 +189,7 @@ class EletrostaticsOverlapFunctor(object):
         elel_2to1 = 2 * np.sum(J_2to1 * mol1_wfn.Da())
         nuel_2to1 = 2 * (self.p.dimer_V.vector_dot(D2) - self.p.monomer2_V.vector_dot(mol2_wfn.Da()))
 
-        ovlp2 = core.Matrix.doublet(self.p.dimer_S, D2, False, False)
+        ovlp2 = core.doublet(self.p.dimer_S, D2, False, False)
 
         overlap = 4 * np.sum(ovlp1.np * ovlp2.np.T)
         #assert abs(elel_1to2 - elel_2to1) < 1e-10
@@ -207,10 +207,10 @@ def orthogonalize(C, S):
     eigvals = core.Vector(nocc)
     sqrt_eigvals = core.Vector(nocc)
 
-    CTSC = core.Matrix.triplet(C, S, C, True, False, False)
+    CTSC = core.triplet(C, S, C, True, False, False)
     CTSC.diagonalize(eigenvectors, eigvals, core.DiagonalizeOrder.Ascending)
 
-    orthonormal = core.Matrix.doublet(C, eigenvectors, False, False)
+    orthonormal = core.doublet(C, eigenvectors, False, False)
 
     sqrt_eigvals.np[:] = np.sqrt(eigvals.np)
     orthonormal.np[:, :] /= sqrt_eigvals.np[np.newaxis, :]

--- a/snsmp2/format_output.py
+++ b/snsmp2/format_output.py
@@ -42,7 +42,7 @@ def format_intene_human(wfncache):
         d = wfncache.wfn_cache[calcid('d', 'd', basis)]
         m1 = wfncache.wfn_cache[calcid('m1', 'd', basis)]
         m2 = wfncache.wfn_cache[calcid('m2', 'd', basis)]
-        return d.get_variable(field) - (m1.get_variable(field) + m2.get_variable(field))
+        return d.variable(field) - (m1.variable(field) + m2.variable(field))
     return {
         ('DF-MP2/%s CP Interaction Energy' % wfncache.basis_sets['high']):
             interaction('MP2 TOTAL ENERGY', basis='high'),
@@ -167,26 +167,26 @@ def format_intene_dict(m1wfn, m2wfn, dwfn):
         'input': _format_input_block_dict(dwfn),
         'output': {
             'dimer': {
-                'reference_energy': dwfn.get_variable('SCF TOTAL ENERGY'),
-                'correlation_energy': dwfn.get_variable('MP2 CORRELATION ENERGY'),
-                'singlet_pair_energy': dwfn.get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'),
-                'triplet_pair_energy': dwfn.get_variable('MP2 SAME-SPIN CORRELATION ENERGY'),
-                'total_energy': dwfn.get_variable('MP2 TOTAL ENERGY'),
+                'reference_energy': dwfn.variable('SCF TOTAL ENERGY'),
+                'correlation_energy': dwfn.variable('MP2 CORRELATION ENERGY'),
+                'singlet_pair_energy': dwfn.variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'),
+                'triplet_pair_energy': dwfn.variable('MP2 SAME-SPIN CORRELATION ENERGY'),
+                'total_energy': dwfn.variable('MP2 TOTAL ENERGY'),
             },
             'monomers': [
                 {
-                    'reference_energy': m1wfn.get_variable('SCF TOTAL ENERGY'),
-                    'correlation_energy': m1wfn.get_variable('MP2 CORRELATION ENERGY'),
-                    'singlet_pair_energy': m1wfn.get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'),
-                    'triplet_pair_energy': m1wfn.get_variable('MP2 SAME-SPIN CORRELATION ENERGY'),
-                    'total_energy': m1wfn.get_variable('MP2 TOTAL ENERGY'),
+                    'reference_energy': m1wfn.variable('SCF TOTAL ENERGY'),
+                    'correlation_energy': m1wfn.variable('MP2 CORRELATION ENERGY'),
+                    'singlet_pair_energy': m1wfn.variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'),
+                    'triplet_pair_energy': m1wfn.variable('MP2 SAME-SPIN CORRELATION ENERGY'),
+                    'total_energy': m1wfn.variable('MP2 TOTAL ENERGY'),
                 },
                 {
-                    'reference_energy': m2wfn.get_variable('SCF TOTAL ENERGY'),
-                    'correlation_energy': m2wfn.get_variable('MP2 CORRELATION ENERGY'),
-                    'singlet_pair_energy': m2wfn.get_variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'),
-                    'triplet_pair_energy': m2wfn.get_variable('MP2 SAME-SPIN CORRELATION ENERGY'),
-                    'total_energy': m2wfn.get_variable('MP2 TOTAL ENERGY'),
+                    'reference_energy': m2wfn.variable('SCF TOTAL ENERGY'),
+                    'correlation_energy': m2wfn.variable('MP2 CORRELATION ENERGY'),
+                    'singlet_pair_energy': m2wfn.variable('MP2 OPPOSITE-SPIN CORRELATION ENERGY'),
+                    'triplet_pair_energy': m2wfn.variable('MP2 SAME-SPIN CORRELATION ENERGY'),
+                    'total_energy': m2wfn.variable('MP2 TOTAL ENERGY'),
                 },
             ]
         }

--- a/snsmp2/snsmp2.py
+++ b/snsmp2/snsmp2.py
@@ -34,7 +34,6 @@
 import os
 import itertools
 import json
-from pkg_resources import parse_version
 import psi4
 from psi4 import core
 import psi4.driver.p4util as p4util
@@ -54,10 +53,7 @@ def run_sns_mp2(name, molecule, **kwargs):
     """Run the SNS-MP2 calculation
     """
     if len(kwargs) > 0:
-        raise ValueError('Unrecognized options: %s' % str(kwargs))
-
-    if parse_version(psi4.__version__) < parse_version('1.3rc2') :
-        raise ValueError('Psi4 {:s} is not compatible (v1.3+ necessary)'.format(psi4.__version__))
+        core.print_out('Unrecognized options: %s' % str(kwargs))
 
     # Force to c1
     molecule = molecule.clone()

--- a/snsmp2/snsmp2.py
+++ b/snsmp2/snsmp2.py
@@ -34,6 +34,8 @@
 import os
 import itertools
 import json
+from pkg_resources import parse_version
+import psi4
 from psi4 import core
 import psi4.driver.p4util as p4util
 import time
@@ -53,6 +55,9 @@ def run_sns_mp2(name, molecule, **kwargs):
     """
     if len(kwargs) > 0:
         raise ValueError('Unrecognized options: %s' % str(kwargs))
+
+    if parse_version(psi4.__version__) <= parse_version('1.3a1') :
+        raise ValueError('Psi4 {:s} is not compatible (v1.3+ necessary)'.format(psi4.__version__))
 
     # Force to c1
     molecule = molecule.clone()

--- a/snsmp2/snsmp2.py
+++ b/snsmp2/snsmp2.py
@@ -144,7 +144,7 @@ def run_sns_mp2(name, molecule, **kwargs):
             dimer_wfn.set_basisset("DF_BASIS_SAPT", aux_basis)
             dimer_wfn.set_basisset("DF_BASIS_ELST", aux_basis)
             core.sapt(dimer_wfn, m1mlow, m2mlow)
-            return {k: core.get_variable(k) for k in ('SAPT ELST10,R ENERGY', 'SAPT EXCH10 ENERGY',
+            return {k: core.variable(k) for k in ('SAPT ELST10,R ENERGY', 'SAPT EXCH10 ENERGY',
                     'SAPT EXCH10(S^2) ENERGY', 'SAPT IND20,R ENERGY', 'SAPT EXCH-IND20,R ENERGY',
                     'SAPT EXCH-DISP20 ENERGY', 'SAPT DISP20 ENERGY', 'SAPT SAME-SPIN EXCH-DISP20 ENERGY',
                     'SAPT SAME-SPIN DISP20 ENERGY', 'SAPT HF TOTAL ENERGY',

--- a/snsmp2/snsmp2.py
+++ b/snsmp2/snsmp2.py
@@ -34,6 +34,7 @@
 import os
 import itertools
 import json
+from pkg_resources import parse_version
 import psi4
 from psi4 import core
 import psi4.driver.p4util as p4util
@@ -54,6 +55,9 @@ def run_sns_mp2(name, molecule, **kwargs):
     """
     if len(kwargs) > 0:
         core.print_out('Unrecognized options: %s' % str(kwargs))
+
+    if parse_version(psi4.__version__) < parse_version('1.3rc2') :
+        raise ImportError('Psi4 {:s} is not compatible (v1.3+ necessary)'.format(psi4.__version__))
 
     # Force to c1
     molecule = molecule.clone()

--- a/snsmp2/snsmp2.py
+++ b/snsmp2/snsmp2.py
@@ -56,7 +56,7 @@ def run_sns_mp2(name, molecule, **kwargs):
     if len(kwargs) > 0:
         raise ValueError('Unrecognized options: %s' % str(kwargs))
 
-    if parse_version(psi4.__version__) <= parse_version('1.3a1') :
+    if parse_version(psi4.__version__) < parse_version('1.3rc2') :
         raise ValueError('Psi4 {:s} is not compatible (v1.3+ necessary)'.format(psi4.__version__))
 
     # Force to c1

--- a/snsmp2/wavefunctioncache.py
+++ b/snsmp2/wavefunctioncache.py
@@ -172,7 +172,6 @@ class WavefunctionCache(object):
         new_wfn = self._basis_projection(oldcalc, calc)
         newfn = self._fmt_mo_fn(calc)
 
-        #np.savez(newfn, **new_data)
         new_wfn.to_file(newfn)
 
         psi_scratch = core.IOManager.shared_object().get_default_path()
@@ -185,9 +184,7 @@ class WavefunctionCache(object):
         assert (oldcalc.B, oldcalc.Z) != (newcalc.B, newcalc.Z)
 
         read_filename = self._fmt_mo_fn(oldcalc)
-
         old_wfn = core.Wavefunction.from_file(read_filename)
-
         Ca_occ = old_wfn.Ca_subset('SO','OCC') 
         Cb_occ = old_wfn.Cb_subset('SO','OCC') 
         puream = old_wfn.basisset().has_puream()
@@ -297,10 +294,8 @@ class WavefunctionCache(object):
 
         m1_C_fn = self._fmt_mo_fn(oldcalc_m1)
         m2_C_fn = self._fmt_mo_fn(oldcalc_m2)
-
         m1_wfn = core.Wavefunction.from_file(m1_C_fn)
         m2_wfn = core.Wavefunction.from_file(m2_C_fn)
-
         m1_Ca_occ = m1_wfn.Ca_subset('SO', 'OCC')  
         m1_Cb_occ = m1_wfn.Cb_subset('SO', 'OCC') 
         m2_Ca_occ = m2_wfn.Ca_subset('SO', 'OCC') 
@@ -310,14 +305,13 @@ class WavefunctionCache(object):
         m2_nso, m2_nalpha = m2_Ca_occ.shape
         m1_nbeta = m1_Cb_occ.shape[1]
         m2_nbeta = m2_Cb_occ.shape[1]
-        assert m1_nso == m2_nso
-
         d_nalpha = m1_nalpha + m2_nalpha
         d_nbeta = m1_nbeta + m2_nbeta
+        assert m1_nso == m2_nso
 
         Ca_d = core.Matrix('Ca', (m1_nso), (m1_nso))
         Cb_d = core.Matrix('Cb', (m1_nso), (m1_nso))
-             
+
         Ca_d.np[:, :m1_nalpha] = m1_Ca_occ.np[:, :]
         Ca_d.np[:, m1_nalpha:d_nalpha] = m2_Ca_occ.np[:, :]
              

--- a/snsmp2/wavefunctioncache.py
+++ b/snsmp2/wavefunctioncache.py
@@ -52,7 +52,7 @@ from .frozencore import nfrozen_core
 #     'm1', 'm2', or 'd'.
 # B : The basis set location. This refers to the set of non-ghosted and ghosted
 #     atoms. It is either 'm1', 'm2', or 'd'
-# V : The basis set quality (i.e. zeta level). It's either 'low' or 'high'.
+# Z : The basis set quality (i.e. zeta level). It's either 'low' or 'high'.
 calcid = namedtuple('calcid', ('V', 'B', 'Z'))
 
 
@@ -169,9 +169,11 @@ class WavefunctionCache(object):
         # Initialize a new namespace for `calc` with an opcast from `oldcalc`.
         assert oldcalc.V == calc.V and oldcalc.B == calc.B
         core.set_local_option('SCF', 'GUESS', 'READ')
-        new_data = self._basis_projection(oldcalc, calc)
+        new_wfn = self._basis_projection(oldcalc, calc)
         newfn = self._fmt_mo_fn(calc)
-        np.savez(newfn, **new_data)
+
+        #np.savez(newfn, **new_data)
+        new_wfn.to_file(newfn)
 
         psi_scratch = core.IOManager.shared_object().get_default_path()
         extras.register_numpy_file(os.path.join(psi_scratch, newfn))
@@ -183,10 +185,12 @@ class WavefunctionCache(object):
         assert (oldcalc.B, oldcalc.Z) != (newcalc.B, newcalc.Z)
 
         read_filename = self._fmt_mo_fn(oldcalc)
-        data = np.load(read_filename)
-        Ca_occ = core.Matrix.np_read(data, "Ca_occ")
-        Cb_occ = core.Matrix.np_read(data, "Cb_occ")
-        puream = int(data["BasisSet PUREAM"])
+
+        old_wfn = core.Wavefunction.from_file(read_filename)
+
+        Ca_occ = old_wfn.Ca_subset('SO','OCC') 
+        Cb_occ = old_wfn.Cb_subset('SO','OCC') 
+        puream = old_wfn.basisset().has_puream()
 
         old_molecule = self.molecule(oldcalc)
         with psiopts('BASIS %s' % self.basis_sets[oldcalc.Z]):
@@ -206,18 +210,29 @@ class WavefunctionCache(object):
             else:
                 base_wfn = core.Wavefunction(new_molecule, new_basis)
 
-        nalphapi = core.Dimension.from_list(data["nalphapi"])
-        nbetapi = core.Dimension.from_list(data["nbetapi"])
-        pCa = base_wfn.basis_projection(Ca_occ, nalphapi, old_basis, new_basis)
-        pCb = base_wfn.basis_projection(Cb_occ, nbetapi, old_basis, new_basis)
+        nso = new_basis.nbf()
+        nalphapi = old_wfn.nalphapi()
+        nbetapi = old_wfn.nbetapi()
+        na = nalphapi.to_tuple()[0]
+        nb = nbetapi.to_tuple()[0]
 
-        new_data = {}
-        new_data.update(pCa.np_write(None, prefix="Ca_occ"))
-        new_data.update(pCb.np_write(None, prefix="Cb_occ"))
-        new_data["reference"] = core.get_option('SCF', 'REFERENCE')
-        new_data["symmetry"] = new_molecule.schoenflies_symbol()
-        new_data["BasisSet"] = new_basis.name()
-        new_data["BasisSet PUREAM"] = puream
+        pCa_occ = base_wfn.basis_projection(Ca_occ, nalphapi, old_basis, new_basis)
+        pCb_occ = base_wfn.basis_projection(Cb_occ, nbetapi, old_basis, new_basis)
+
+        pCa = np.zeros((nso , nso))
+        pCb = np.zeros((nso , nso))
+        pCa[:,:na] = pCa_occ.np[:,:]
+        pCb[:,:nb] = pCb_occ.np[:,:]
+
+        new_wfn = old_wfn.to_file()
+        new_wfn['matrix']['Ca'] = pCa
+        new_wfn['matrix']['Cb'] = pCb
+        new_wfn['dimension']['nsopi'] = (nso,)
+        new_wfn['dimension']['nmopi'] = (nso,)
+        new_wfn['int']['nso'] = nso
+        new_wfn['int']['nmo'] = nso
+        new_wfn['molecule'] = new_molecule.to_dict()
+        new_wfn['string']['basisname'] = new_basis.name()
 
         core.print_out('\n Computing basis set projection from {calc1} to {calc2} (elapsed={time:.2f})\n'.format(
             calc1=self._display_name(oldcalc).lower(),
@@ -225,26 +240,23 @@ class WavefunctionCache(object):
             time=time.time()-start_time,
         ))
 
-        # Workaround for https://github.com/psi4/psi4/pull/750
-        for key, value in new_data.items():
-            if isinstance(value, np.ndarray) and value.flags['OWNDATA'] == False:
-                new_data[key] = np.copy(value)
-
-        return new_data
+        return core.Wavefunction.from_file(new_wfn)
 
     def _fmt_mo_fn(self, calc):
         # type: (calcid,) -> str
         # Path to the molecular orbital file for a calc.
         fname = os.path.split(os.path.abspath(core.get_writer_file_prefix(self.fmt_ns(calc))))[1]
-        return "%s.%s.npz" % (fname, psif.PSIF_SCF_MOS)
+        return "%s.%s.npy" % (fname, psif.PSIF_SCF_MOS)
 
     def _init_addghost_C(self, oldcalc, calc):
         # print('Adding ghost %s->%s' % (oldcalc, calc))
 
         old_filename = self._fmt_mo_fn(oldcalc)
-        data = np.load(old_filename)
-        Ca_occ = core.Matrix.np_read(data, "Ca_occ")
-        Cb_occ = core.Matrix.np_read(data, "Cb_occ")
+
+        wfn = core.Wavefunction.from_file(old_filename)
+
+        Ca_occ = wfn.Ca_subset('SO','OCC') 
+        Cb_occ = wfn.Cb_subset('SO','OCC') 
 
         m1_nso = self.wfn_cache[('m1', 'm', oldcalc.Z)].nso()
         m2_nso = self.wfn_cache[('m2', 'm', oldcalc.Z)].nso()
@@ -253,25 +265,28 @@ class WavefunctionCache(object):
         m1_nbeta = self.wfn_cache[('m1', 'm', oldcalc.Z)].nbeta()
         m2_nbeta = self.wfn_cache[('m2', 'm', oldcalc.Z)].nbeta()
 
+        Ca_d = np.zeros((m1_nso + m2_nso , m1_nso + m2_nso ))
+        Cb_d = np.zeros((m1_nso + m2_nso , m1_nso + m2_nso ))
         if calc.V == 'm1':
-            Ca_occ_d = core.Matrix('Ca_occ', (m1_nso + m2_nso), m1_nalpha)
-            Ca_occ_d.np[:m1_nso, :] = Ca_occ.np[:, :]
-            Cb_occ_d = core.Matrix('Cb_occ', (m1_nso + m2_nso), m1_nbeta)
-            Cb_occ_d.np[:m1_nso, :] = Cb_occ.np[:, :]
+            Ca_d[:m1_nso, :m1_nalpha] = Ca_occ
+            Cb_d[:m1_nso, :m1_nbeta] = Cb_occ
         elif calc.V == 'm2':
-            Ca_occ_d = core.Matrix('Ca_occ', (m1_nso + m2_nso), m2_nalpha)
-            Ca_occ_d.np[-m2_nso:, :] = Ca_occ.np[:, :]
+            Ca_d[-m2_nso:, :m2_nalpha] = Ca_occ
+            Cb_d[-m2_nso:, :m2_nbeta] = Cb_occ
 
-            Cb_occ_d = core.Matrix('Cb_occ', (m1_nso + m2_nso), m2_nbeta)
-            Cb_occ_d.np[-m2_nso:, :] = Cb_occ.np[:, :]
+        wfn_new = wfn.to_file()
+        wfn_new['matrix']['Ca'] = Ca_d
+        wfn_new['matrix']['Cb'] = Cb_d
+        wfn_new['dimension']['nsopi'] = (m1_nso + m2_nso,)
+        wfn_new['dimension']['nmopi'] = (m1_nso + m2_nso,)
+        wfn_new['int']['nso'] = m1_nso + m2_nso 
+        wfn_new['int']['nmo'] = m1_nso + m2_nso 
 
-        data_dict = dict(data)
-        data_dict.update(Ca_occ_d.np_write(prefix='Ca_occ'))
-        data_dict.update(Cb_occ_d.np_write(prefix='Cb_occ'))
+        wfn_new = core.Wavefunction.from_file(wfn_new)
 
         psi_scratch = core.IOManager.shared_object().get_default_path()
-        write_filename = os.path.join(psi_scratch, os.path.split(os.path.abspath(core.get_writer_file_prefix(self.fmt_ns(calc))))[1] + ".180.npz")
-        np.savez(write_filename, **data_dict)
+        write_filename = os.path.join(psi_scratch, os.path.split(os.path.abspath(core.get_writer_file_prefix(self.fmt_ns(calc))))[1] + ".180.npy")
+        wfn_new.to_file(write_filename)
         extras.register_numpy_file(write_filename)
         core.set_local_option('SCF', 'GUESS', 'READ')
 
@@ -282,12 +297,14 @@ class WavefunctionCache(object):
 
         m1_C_fn = self._fmt_mo_fn(oldcalc_m1)
         m2_C_fn = self._fmt_mo_fn(oldcalc_m2)
-        m1_data = np.load(m1_C_fn)
-        m2_data = np.load(m2_C_fn)
-        m1_Ca_occ = core.Matrix.np_read(m1_data, "Ca_occ")
-        m1_Cb_occ = core.Matrix.np_read(m1_data, "Cb_occ")
-        m2_Ca_occ = core.Matrix.np_read(m2_data, "Ca_occ")
-        m2_Cb_occ = core.Matrix.np_read(m2_data, "Cb_occ")
+
+        m1_wfn = core.Wavefunction.from_file(m1_C_fn)
+        m2_wfn = core.Wavefunction.from_file(m2_C_fn)
+
+        m1_Ca_occ = m1_wfn.Ca_subset('SO', 'OCC')  
+        m1_Cb_occ = m1_wfn.Cb_subset('SO', 'OCC') 
+        m2_Ca_occ = m2_wfn.Ca_subset('SO', 'OCC') 
+        m2_Cb_occ = m2_wfn.Cb_subset('SO', 'OCC') 
 
         m1_nso, m1_nalpha = m1_Ca_occ.shape
         m2_nso, m2_nalpha = m2_Ca_occ.shape
@@ -295,35 +312,35 @@ class WavefunctionCache(object):
         m2_nbeta = m2_Cb_occ.shape[1]
         assert m1_nso == m2_nso
 
-        d_Ca_occ = core.Matrix('Ca_occ', (m1_nso), (m1_nalpha + m2_nalpha))
-        d_Cb_occ = core.Matrix('Cb_occ', (m1_nso), (m1_nbeta + m2_nbeta))
+        d_nalpha = m1_nalpha + m2_nalpha
+        d_nbeta = m1_nbeta + m2_nbeta
 
-        d_Ca_occ.np[:, :m1_nalpha] = m1_Ca_occ.np[:, :]
-        d_Ca_occ.np[:, -m2_nalpha:] = m2_Ca_occ.np[:, :]
+        Ca_d = core.Matrix('Ca', (m1_nso), (m1_nso))
+        Cb_d = core.Matrix('Cb', (m1_nso), (m1_nso))
+             
+        Ca_d.np[:, :m1_nalpha] = m1_Ca_occ.np[:, :]
+        Ca_d.np[:, m1_nalpha:d_nalpha] = m2_Ca_occ.np[:, :]
+             
+        Cb_d.np[:, :m1_nbeta] = m1_Cb_occ.np[:, :]
+        Cb_d.np[:, m1_nalpha:d_nbeta:] = m2_Cb_occ.np[:, :]
 
-        d_Cb_occ.np[:, :m1_nbeta] = m1_Cb_occ.np[:, :]
-        d_Cb_occ.np[:, -m2_nbeta:] = m2_Cb_occ.np[:, :]
+        assert m1_wfn.molecule().schoenflies_symbol() == m2_wfn.molecule().schoenflies_symbol() == 'c1'
+        assert m1_wfn.name() == m2_wfn.name()
+        assert m1_wfn.basisset().name() == m2_wfn.basisset().name()
+        assert m1_wfn.basisset().has_puream() == m2_wfn.basisset().has_puream()
 
-        assert m1_data['symmetry'] == m2_data['symmetry'] == 'c1'
-        assert m1_data['reference'] == m2_data['reference']
-        assert m1_data['BasisSet'] == m2_data['BasisSet']
-        assert m1_data['BasisSet PUREAM'] == m2_data['BasisSet PUREAM']
+        wfn_new = m1_wfn.to_file()
 
-        data = {
-            'symmetry': m1_data['symmetry'],
-            'reference': m1_data['reference'],
-            'ndoccpi': m1_data['ndoccpi'] + m2_data['ndoccpi'],
-            'nsoccpi': m1_data['nsoccpi'] + m2_data['nsoccpi'],
-            'nalphapi': m1_data['nalphapi'] + m2_data['nalphapi'],
-            'nbetapi': m1_data['nbetapi'] + m2_data['nbetapi'],
-            'BasisSet': m1_data['BasisSet'],
-            'BasisSet PUREAM': m1_data['BasisSet PUREAM'],
-        }
+        wfn_new['dimension']['nalphapi'] = (m1_nalpha + m2_nalpha,)
+        wfn_new['dimension']['nbetapi'] = (m1_nbeta + m2_nbeta,)
+        wfn_new['dimension']['doccpi'] = (m1_wfn.doccpi().to_tuple()[0] + m2_wfn.doccpi().to_tuple()[0],)
+        wfn_new['dimension']['soccpi'] = (m1_wfn.soccpi().to_tuple()[0] + m2_wfn.soccpi().to_tuple()[0],)
+        wfn_new['matrix']['Ca'] = Ca_d
+        wfn_new['matrix']['Cb'] = Cb_d
 
-        data.update(d_Ca_occ.np_write(prefix='Ca_occ'))
-        data.update(d_Cb_occ.np_write(prefix='Cb_occ'))
+        wfn_new = core.Wavefunction.from_file(wfn_new)
         m1_C_fn = self._fmt_mo_fn(calc)
-        np.savez(m1_C_fn, **data)
+        wfn_new.to_file(m1_C_fn)
 
         core.set_local_option('SCF', 'GUESS', 'READ')
 

--- a/tests/2x{CC}.in
+++ b/tests/2x{CC}.in
@@ -29,10 +29,10 @@ no_reorient
 
 energy('sns-mp2')
 
-compare_values( 2.57199e-02, get_variable('DF-HF/desavqz-psi-rev1 Density Matrix Overlap'),            6, "ovlhf")
-compare_values(-1.07132e-03, get_variable('DF-HF/desavqz-psi-rev1 Electrostatic Interaction Energy'),  6, "eshf")
-compare_values( 2.55943e-03, get_variable('DF-HF/desavqz-psi-rev1 Heitler-London Energy'),             6, "hl")
-compare_values( 2.82251e-02, get_variable('DF-MP2/desavqz-psi-rev1 Density Matrix Overlap'),           6, "ovlmp")
-compare_values(-1.22020e-03, get_variable('DF-MP2/desavqz-psi-rev1 Electrostatic Interaction Energy'), 6, "esmp")
-compare_values( 2.25913e-03, get_variable('DF-HF/desavqz-psi-rev1 CP Interaction Energy'),             5, "inthf")
-compare_values(-2.14025e-03, get_variable('DF-MP2/desavqz-psi-rev1 CP Interaction Energy'),            5, "intmp")
+compare_values( 2.57199e-02, variable('DF-HF/desavqz Density Matrix Overlap'),            6, "ovlhf")
+compare_values(-1.07132e-03, variable('DF-HF/desavqz Electrostatic Interaction Energy'),  6, "eshf")
+compare_values( 2.55943e-03, variable('DF-HF/desavqz Heitler-London Energy'),             6, "hl")
+compare_values( 2.82251e-02, variable('DF-MP2/desavqz Density Matrix Overlap'),           6, "ovlmp")
+compare_values(-1.22020e-03, variable('DF-MP2/desavqz Electrostatic Interaction Energy'), 6, "esmp")
+compare_values( 2.25913e-03, variable('DF-HF/desavqz CP Interaction Energy'),             5, "inthf")
+compare_values(-2.14025e-03, variable('DF-MP2/desavqz CP Interaction Energy'),            5, "intmp")

--- a/tests/{CF}_O.in
+++ b/tests/{CF}_O.in
@@ -20,10 +20,10 @@ symmetry c1
 
 energy('sns-mp2')
 
-compare_values( 0.02957596, get_variable('DF-HF/desavqz Density Matrix Overlap'),             6, "ovlhf")
-compare_values(-0.00863467, get_variable('DF-HF/desavqz Electrostatic Interaction Energy'),   6, "eshf")
-compare_values(-0.00143114, get_variable('DF-HF/desavqz Heitler-London Energy'),              6, "hl")
-compare_values( 0.03455406, get_variable('DF-MP2/desavqz Density Matrix Overlap'),            6, "ovlmp")
-compare_values(-0.00841727, get_variable('DF-MP2/desavqz Electrostatic Interaction Energy'),  6, "esmp")
-compare_values(-0.00348609, get_variable('DF-HF/desavqz CP Interaction Energy'),              5, "inthf")
-compare_values(-0.00597490, get_variable('DF-MP2/desavqz CP Interaction Energy'),             5, "intmp")
+compare_values( 0.02957596, variable('DF-HF/desavqz Density Matrix Overlap'),             6, "ovlhf")
+compare_values(-0.00863467, variable('DF-HF/desavqz Electrostatic Interaction Energy'),   6, "eshf")
+compare_values(-0.00143114, variable('DF-HF/desavqz Heitler-London Energy'),              6, "hl")
+compare_values( 0.03455406, variable('DF-MP2/desavqz Density Matrix Overlap'),            6, "ovlmp")
+compare_values(-0.00841727, variable('DF-MP2/desavqz Electrostatic Interaction Energy'),  6, "esmp")
+compare_values(-0.00348609, variable('DF-HF/desavqz CP Interaction Energy'),              5, "inthf")
+compare_values(-0.00597490, variable('DF-MP2/desavqz CP Interaction Energy'),             5, "intmp")


### PR DESCRIPTION
The mechanism of storing/reading SCF guess orbitals in Psi4 is changing to make use of wavefunction serialization, as discussed [here](https://github.com/psi4/psi4/issues/1514). This PR alters snsmp2's `WavefunctionCache` class, which makes heavy use of this functionality, in order to be compatible with version 1.3 of Psi4.